### PR TITLE
Fix error in checking for Obliteration talent

### DIFF
--- a/deathknight.lua
+++ b/deathknight.lua
@@ -590,7 +590,7 @@ function ConRO.DeathKnight.Frost(_, timeShift, currentSpell, gcd, tChosen, pvpCh
 
 --Rotations
 		if tChosen[Passive.ColdHeart.talentID] then
-			if tChosen[Ability.Obliteration.talentID] then
+			if tChosen[Passive.Obliteration.talentID] then
 				if _ChainsofIce_RDY and not _PillarofFrost_BUFF and (_ColdHeart_COUNT >= 20 or (_UnholyStrength_BUFF and _UnholyStrength_DUR <= 2 and _ColdHeart_COUNT >= 17)) then
 					tinsert(ConRO.SuggestedSpells, _ChainsofIce);
 				end


### PR DESCRIPTION
Referenced in the discord bug channel.

I've made these changes locally and tested with success.

```
Message: Interface/AddOns/ConRO_DeathKnight/deathknight.lua:593: attempt to index field 'Obliteration' (a nil value)
Time: Sat Feb 11 23:28:18 2023
Count: 1
Stack: Interface/AddOns/ConRO_DeathKnight/deathknight.lua:593: attempt to index field 'Obliteration' (a nil value)
[string "=[C]"]: ?
[string "@Interface/AddOns/ConRO_DeathKnight/deathknight.lua"]:593: in function `NextSpell'
[string "@Interface/AddOns/ConRO/core.lua"]:2796: in function `?'
[string "@Interface/AddOns/ConRO/Libs/AceTimer-3.0/AceTimer-3.0.lua"]:55: in function <...face/AddOns/ConRO/Libs/AceTimer-3.0/AceTimer-3.0.lua:50>
```